### PR TITLE
Switch from 'colorize' to 'rainbow'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     kovid (0.2.6)
-      colorize (~> 0.8)
+      rainbow (~> 3.0)
       terminal-table (~> 1.8)
       thor (~> 1.0)
       typhoeus (~> 1.3)
@@ -21,7 +21,6 @@ GEM
     builder (3.2.4)
     childprocess (3.0.0)
     coderay (1.1.2)
-    colorize (0.8.1)
     contracts (0.16.0)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -51,6 +50,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    rainbow (3.0.0)
     rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -89,4 +89,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/kovid.gemspec
+++ b/kovid.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 1.8"
   spec.add_dependency "typhoeus", "~> 1.3"
-  spec.add_dependency "colorize", "~> 0.8"
+  spec.add_dependency "rainbow", "~> 3.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "cucumber"

--- a/lib/kovid/painter.rb
+++ b/lib/kovid/painter.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'colorize'
+require 'rainbow'
 
 class String
   def paint_white
-    colorize(:white).colorize(background: :black).colorize(mode: :bold)
+    Rainbow(self).white.bg(:black).bold
   end
 
   def paint_red
-    colorize(:red).colorize(background: :black).colorize(mode: :bold)
+    Rainbow(self).red.bg(:black).bold
   end
 
   def paint_green
-    colorize(:green).colorize(background: :black).colorize(mode: :bold)
+    Rainbow(self).green.bg(:black).bold
   end
 
   def paint_yellow
-    colorize(:yellow).colorize(background: :black).colorize(mode: :bold)
+    Rainbow(self).yellow.bg(:black).bold
   end
 end


### PR DESCRIPTION
Unfortunately, 'colorize' gem is licensed under GPLv2 which means you can only use it if all the work that depends on it is licensed under the same or similar license (demands all dependant work to be open source). There's a gem that provides the same functionality, but is licensed under the MIT license.

This PR switches from colorize to rainbow.

https://github.com/fazibear/colorize
https://github.com/sickill/rainbow