### PR TITLE
Remove empty days in history

### DIFF
--- a/lib/kovid/tablelize.rb
+++ b/lib/kovid/tablelize.rb
@@ -195,6 +195,9 @@ module Kovid
                   country['timeline']['cases'].keys
                 end
 
+
+        stats.reject! { |stat| stat[0].to_i.zero? && stat[1].to_i.zero? } unless last
+
         stats.each_with_index do |val, index|
           date_to_parse = Date.strptime(dates[index], '%m/%d/%y').to_s
           val.unshift(Date.parse(date_to_parse).strftime('%d %b, %y'))


### PR DESCRIPTION
To make history commnad more readable all days with no value should be removed. 
What do you think?

This is current state:
![Screenshot from 2020-03-26 18-40-55](https://user-images.githubusercontent.com/3482328/77678374-5aa62380-6f91-11ea-9d5a-afcb2082b373.png)
