### PR TITLE
Return a non-zero exit code on failure

### DIFF
--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -6,6 +6,10 @@ require 'kovid'
 module Kovid
   class CLI < Thor
     FULL_FLAG = %w[-f --full].freeze
+    
+    def self.exit_on_failure?
+      true
+    end
 
     desc 'check COUNTRY or check "COUNTRY NAME"', 'Returns reported data on provided country. eg: "kovid check "hong kong".'
     method_option :full, aliases: '-f'


### PR DESCRIPTION
Right now if a command fails, it returns an exit code 0, which should mean the program ran successfully.

This PR causes failures to return 1.