### PR TITLE
Add provinces functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ You can get continental information with the following commands:
 You can fetch US state-specific data:
 * `kovid state STATE` OR `kovid state "STATE NAME"`.
 
+Provinces
+
+You can fetch province specific data:
+
+* `kovid province PROVINCE` or `kovid province "PROVINCE NAME"`.
+
 ___
 😷 **Comparing**
 * `kovid compare FOO BAR` (sorts by cases DESC).
@@ -56,6 +62,9 @@ You can compare as many countries as you want; `kovid compare FOO BAR BAZ` OR `k
 
 You can compare US states with:
 * `kovid compare STATE STATE` Example: `kovid states illinois "new york" california`
+
+You can compare provicnes with:
+* `kovid provinces PROVINCE PROVINCE` Example: `kovid provinces ontario manitoba`
 ___
 😷 **History**
 * `kovid history COUNTRY` (full history).

--- a/lib/kovid.rb
+++ b/lib/kovid.rb
@@ -38,6 +38,14 @@ module Kovid
     Kovid::Request.by_country_full(name)
   end
 
+  def province(name)
+    Kovid::Request.province(name)
+  end
+  
+  def provinces(names)
+    Kovid::Request.provinces(names)
+  end
+
   def state(state)
     Kovid::Request.state(state)
   end

--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -11,6 +11,18 @@ module Kovid
       true
     end
 
+    desc 'province PROVINCE or province "PROVINCE NAME"', 'Returns reported data on provided province. eg "kovid check "new brunswick".'
+    method_option :full, aliases: '-p'
+    def province(name)
+      puts Kovid.province(name)
+      data_source
+    end
+
+    desc 'provinces PROVINCE PROVINCE', 'Returns full comparison table for the given provinces. Accepts multiple provinces.'
+    def provinces(*names)
+      puts Kovid.provinces(names)
+    end
+
     desc 'check COUNTRY or check "COUNTRY NAME"', 'Returns reported data on provided country. eg: "kovid check "hong kong".'
     method_option :full, aliases: '-f'
     def check(name)

--- a/lib/kovid/tablelize.rb
+++ b/lib/kovid/tablelize.rb
@@ -78,6 +78,13 @@ module Kovid
         'Active'.paint_yellow
       ].freeze
 
+      COMPARE_PROVINCES_HEADINGS = [
+        'Province'.paint_white,
+        'Confirmed'.paint_white,
+        'Deaths'.paint_red,
+        'Recovered'.paint_green
+      ].freeze
+
       FOOTER_LINE = ['------------', '------------', '------------', '------------'].freeze
       COUNTRY_LETTERS = 'A'.upto('Z').with_index(127_462).to_h.freeze
 
@@ -124,6 +131,18 @@ module Kovid
                               headings: FULL_COUNTRY_TABLE_HEADINGS,
                               rows: rows)
         end
+      end
+
+      def full_province_table(province)
+        headings = [
+          'Confirmed'.paint_white,
+          'Deaths'.paint_red,
+          'Recovered'.paint_green
+        ]
+        rows = []
+        rows << [province['stats']['confirmed'], province['stats']['deaths'], province['stats']['recovered']]
+
+        Terminal::Table.new(title: province['province'].upcase, headings: headings, rows: rows)
       end
 
       def full_state_table(state)
@@ -193,6 +212,19 @@ module Kovid
         end
 
         Terminal::Table.new(headings: COMPARE_STATES_HEADINGS, rows: rows)
+      end
+
+      def compare_provinces(data)
+        rows = data.map do |province|
+          [
+            province['province'].upcase,
+            province['stats']['confirmed'],
+            province['stats']['deaths'],
+            province['stats']['recovered']
+          ]
+        end
+
+        Terminal::Table.new(headings: COMPARE_PROVINCES_HEADINGS, rows: rows)
       end
 
       def cases(cases)

--- a/spec/kovid_spec.rb
+++ b/spec/kovid_spec.rb
@@ -5,6 +5,35 @@ RSpec.describe Kovid do
     expect(Kovid::VERSION).not_to be nil
   end
 
+  describe 'province(name)' do
+    let(:province) { 'ontario' }
+    let(:inexistent_province) { 'wonderland' }
+    it 'returns table with province data' do
+      table = Kovid.province(province)
+
+      expect(table.title).to include('ONTARIO')
+    end
+
+    it 'outputs message informing of wrong spelling or no reported case.' do
+      table = Kovid.province(inexistent_province)
+      not_found = "Wrong spelling/No reported cases on #{inexistent_province.upcase}."
+
+      expect(table.rows.first.cells.first.value).to eq(not_found)
+    end
+  end
+
+  describe 'provinces(names)' do
+    let(:provinces) { %w(ontario manitoba) }
+    
+    it 'returns table with provinces data' do
+      table = Kovid.provinces(provinces)
+
+      first_columns = table.rows.map { |row| row.cells.first.value }
+      
+      expect(first_columns).to include("MANITOBA").and include("ONTARIO")
+    end
+  end
+
   describe 'country(name)' do
     let(:country) { 'ghana' }
     let(:inexistent_country) { 'wonderland' }


### PR DESCRIPTION
This adds the `province` command, and `provinces` command. Behaves the same as the corresponding states commands.

This isn't limited to Canadian provinces. Should be able to use any of the provinces as listed by the hopkins response.


resolves #83 