### PR TITLE
Allow for all US state comparison and fix specified state comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ You can get continental information with the following commands:
 
 You can fetch US state-specific data:
 * `kovid state STATE` OR `kovid state "STATE NAME"`.
+* `kovid all_us_states`.
 
 Provinces
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can get continental information with the following commands:
 
 You can fetch US state-specific data:
 * `kovid state STATE` OR `kovid state "STATE NAME"`.
-* `kovid all_us_states`.
+* `kovid aus` for data on all US states.
 
 Provinces
 

--- a/lib/kovid.rb
+++ b/lib/kovid.rb
@@ -54,6 +54,10 @@ module Kovid
     Kovid::Request.states(states)
   end
 
+  def all_us_states
+    Kovid::Request.all_us_states
+  end
+
   def country_comparison(names_array)
     Kovid::Request.by_country_comparison(names_array)
   end

--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -56,7 +56,10 @@ module Kovid
 
     desc 'states STATE STATE', 'Returns full comparison table for the given states. Accepts multiple states.'
     def states(*states)
-      puts Kovid.states(states)
+      # This ensures this command is case insensitive.
+      downcased_states = states.map(&:downcase)
+
+      puts Kovid.states(downcased_states)
       data_source
     end
 

--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -60,6 +60,12 @@ module Kovid
       data_source
     end
 
+    desc 'all_us_states', 'Returns full comparison table for all US states'
+    def all_us_states
+      puts Kovid.all_us_states
+      data_source
+    end
+
     desc 'world', 'Returns total number of cases, deaths and recoveries.'
     def world
       puts Kovid.cases

--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -68,6 +68,7 @@ module Kovid
       puts Kovid.all_us_states
       data_source
     end
+    map aus: :all_us_states
 
     desc 'world', 'Returns total number of cases, deaths and recoveries.'
     def world

--- a/lib/kovid/request.rb
+++ b/lib/kovid/request.rb
@@ -117,10 +117,10 @@ module Kovid
         puts SERVER_DOWN
       end
 
-      def states(list)
-        array = fetch_states(list)
+      def states(states)
+        compared_states = fetch_compared_states(states)
 
-        Kovid::Tablelize.compare_us_states(array)
+        Kovid::Tablelize.compare_us_states(compared_states)
       rescue JSON::ParserError
         puts SERVER_DOWN
       end
@@ -191,13 +191,10 @@ module Kovid
         array = array.sort_by { |json| -json['cases'] }
       end
 
-      def fetch_states(list)
-        states_json = JSON.parse(Typhoeus.get(STATES_URL, cache_ttl: 900).response_body)
-        states_array = []
+      def fetch_compared_states(submitted_states)
+        state_data = fetch_state_data
 
-        states_json.select do |state|
-          states_array << state if list.include?(state['state'].downcase)
-        end
+        state_data.select { |state| submitted_states.include?(state['state'].downcase) }
       end
 
       def fetch_state_data

--- a/lib/kovid/request.rb
+++ b/lib/kovid/request.rb
@@ -193,6 +193,10 @@ module Kovid
         state_data.select { |state| submitted_states.include?(state['state'].downcase) }
       end
 
+      def fetch_state_data
+        JSON.parse(Typhoeus.get(STATES_URL, cache_ttl: 900).response_body)
+      end
+
       def fetch_country(country_name)
         country_url = COUNTRIES_PATH + "/#{country_name}"
 

--- a/lib/kovid/request.rb
+++ b/lib/kovid/request.rb
@@ -125,6 +125,13 @@ module Kovid
         puts SERVER_DOWN
       end
 
+      def all_us_states
+        state_data = fetch_state_data
+        Kovid::Tablelize.compare_us_states(state_data)
+      rescue JSON::ParserError
+        puts SERVER_DOWN
+      end
+
       def by_country_comparison(list)
         array = fetch_countries(list)
         Kovid::Tablelize.compare_countries_table(array)
@@ -191,6 +198,10 @@ module Kovid
         states_json.select do |state|
           states_array << state if list.include?(state['state'].downcase)
         end
+      end
+
+      def fetch_state_data
+        JSON.parse(Typhoeus.get(STATES_URL, cache_ttl: 900).response_body)
       end
 
       def fetch_country(country_name)

--- a/spec/kovid_spec.rb
+++ b/spec/kovid_spec.rb
@@ -116,6 +116,18 @@ RSpec.describe Kovid do
     end
   end
 
+  describe 'all_us_states' do
+    before do
+      allow(Kovid::Request).to receive(:all_us_states)
+    end
+
+    it 'calls all_us_states on Kovid::Request' do
+      Kovid.all_us_states
+
+      expect(Kovid::Request).to have_received(:all_us_states)
+    end
+  end
+
   describe 'history' do
     it 'returns history of given location' do
       table = Kovid.history('ghana', '7')


### PR DESCRIPTION
Sorry to do 2 things in 1 pr, but it seemed to make sense because they both rely on the `fetch_state_data` method I added. 

### Adding All State Comparison
Output is the following:
![image](https://user-images.githubusercontent.com/11525911/78461980-71383300-7693-11ea-9337-f1a78271699f.png)

### Fixing specified US state comparison.
Prior to this change running `kovid states Florida Tennessee`, for example, would output the following.
![image](https://user-images.githubusercontent.com/11525911/78461920-a6905100-7692-11ea-8325-b21ffcb5a04c.png)

Now the output is as follows:
![image](https://user-images.githubusercontent.com/11525911/78461998-9167f200-7693-11ea-9a62-bf3692e6495b.png)

### Notes on Specs
This [spec](https://github.com/siaw23/kovid/compare/master...DylanAndrews:feature/all-us-state-comparison?expand=1#diff-b663486c58638f9ef6d86ead58476518R119-R130) may seem strange, but I made it this way because I feel strongly that we should move in the direction of using stubs. I plan to create another pr very soon that addresses the need for stubbing in other areas of the spec file and ensure this added functionality has full spec coverage, but for now I just added this. 

### Notes on variable and argument name changes
I did this for the sake of clarity. In general I think it will be best if we avoid names like `array`, as it is less clear than alternatives. Happy to discuss further if you like. 

Thanks again for doing the work on the gem. It's awesome.
