### PR TITLE
add state abbreviations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ gemspec
 
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
+
+# Repo of geogrpahic locations
+gem 'carmen', '~> 1.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,12 +11,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ascii_charts (0.9.1)
+    carmen (1.1.3)
+      activesupport (>= 3.0.0)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     docile (1.3.2)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     ffi (1.12.2)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.0)
     rainbow (3.0.0)
     rake (12.3.3)
     rspec (3.9.0)
@@ -39,14 +51,19 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
+    thread_safe (0.3.6)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  carmen (~> 1.1.3)
   kovid!
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can fetch US state-specific data:
 * `kovid state STATE` OR `kovid state "STATE NAME"`.
 * `kovid states --all` or `kovid states -a` for data on all US states.
 
+You can also use USPS abbreviations.  Example: `kovid state me`
+
 Provinces
 
 You can fetch province specific data:
@@ -64,7 +66,7 @@ You can compare as many countries as you want; `kovid compare FOO BAR BAZ` OR `k
 🇺🇸🇺🇸🇺🇸
 
 You can compare US states with:
-* `kovid states STATE STATE` Example: `kovid states illinois "new york" california`
+* `kovid states STATE STATE` Example: `kovid states illinois "new york" california` OR `kovid states il ny ca`
 
 You can compare provicnes with:
 * `kovid provinces PROVINCE PROVINCE` Example: `kovid provinces ontario manitoba`

--- a/lib/kovid/helpers.rb
+++ b/lib/kovid/helpers.rb
@@ -30,4 +30,10 @@ module Kovid
       data.map! { |number| Kovid.comma_delimit(number) }
     end
   end
+
+  def lookup_us_state(state)
+    us = Carmen::Country.coded('USA')
+    lookup = us.subregions.coded(state) || us.subregions.named(state)
+    lookup ? lookup.name : state
+  end
 end

--- a/lib/kovid/request.rb
+++ b/lib/kovid/request.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'carmen'
 require_relative 'tablelize'
 require_relative 'cache'
 require_relative 'uri_builder'
@@ -109,7 +110,7 @@ module Kovid
       end
 
       def state(state)
-        response = fetch_state(state)
+        response = fetch_state(Kovid.lookup_us_state(state))
         if response.nil?
           not_found(state)
         else
@@ -121,7 +122,6 @@ module Kovid
 
       def states(states)
         compared_states = fetch_compared_states(states)
-
         Kovid::Tablelize.compare_us_states(compared_states)
       rescue JSON::ParserError
         puts SERVER_DOWN
@@ -204,10 +204,10 @@ module Kovid
       end
 
       def fetch_compared_states(submitted_states)
-        state_data = fetch_state_data
+        submitted_states.map! { |s| Kovid.lookup_us_state(s) }
 
-        state_data.select do |state|
-          submitted_states.include?(state['state'].downcase)
+        fetch_state_data.select do |state|
+          submitted_states.include?(state['state'])
         end
       end
 

--- a/spec/kovid_spec.rb
+++ b/spec/kovid_spec.rb
@@ -125,11 +125,31 @@ RSpec.describe Kovid do
   end
 
   describe 'state' do
+
     it 'returns a US state data' do
       table = Kovid.state('michigan')
 
       expect(table.headings.first.cells.first.value).to include('Cases')
       expect(table.headings.first.cells.last.value).to include('Active')
+    end
+
+    it 'accepts US state abbreviations' do
+      expect(Kovid.state('michigan').title).to eq Kovid.state('mi').title
+      expect(Kovid.state('Alabama').title).to eq Kovid.state('AL').title
+      expect(Kovid.state('Maine').title).to eq Kovid.state('Me').title
+    end
+
+    it 'outputs message informing of wrong spelling or no reported case.' do
+      expect(Kovid.state("Mediocristan").title).to eq("You checked: MEDIOCRISTAN")
+    end
+
+  end
+
+  describe 'states' do
+    let(:us_states) { %w[AK CA NY VA] }
+    it 'returns table with state data' do
+      table = Kovid.states(us_states)
+      expect(table.rows.size).to eq(4)
     end
   end
 


### PR DESCRIPTION
hi - i noticed that the API you're using handles alpha2 and alpha3 codes when searching countries, but the API does not handle USPS codes for United States data.

For example `/countries/KR` will return data for Korea.  However, `/v2/states/NY`, will not return data for New York.

I've added proof of concept for handling United States codes.  It makes it much easier to compare states:

`kovid check va ny ca tx`

I could also add same logic for Provinces, so you could also do `kovid province ON` instead of `kovid province Ontario`



