### PR TITLE
Move dependency to correct location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,3 @@ gemspec
 
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
-
-# Repo of geogrpahic locations
-gem 'carmen', '~> 1.1.3'

--- a/kovid.gemspec
+++ b/kovid.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terminal-table', '~> 1.8'
   spec.add_dependency 'thor', '~> 1.0'
   spec.add_dependency 'typhoeus', '~> 1.3'
-
+  spec.add_dependency 'carmen', '~> 1.1.3'
   spec.add_development_dependency 'simplecov', '~>  0.18'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
The carmen dep was added to the Gemfile when it should have been in the gemspec. The latest version of the gem throws upon use:

```
Traceback (most recent call last):
        13: from /home/cereal/.rbenv/versions/2.7.0/bin/kovid:23:in `<main>'
        12: from /home/cereal/.rbenv/versions/2.7.0/bin/kovid:23:in `load'
        11: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/kovid-0.6.7/exe/kovid:4:in `<top (required)>'
        10: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         9: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         8: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/kovid-0.6.7/lib/kovid/cli.rb:4:in `<top (required)>'
         7: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         6: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         5: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/kovid-0.6.7/lib/kovid.rb:4:in `<top (required)>'
         4: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         3: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
         2: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/kovid-0.6.7/lib/kovid/request.rb:4:in `<top (required)>'
         1: from /home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/home/cereal/.rbenv/versions/2.7.0/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- carmen (LoadError)
```