### PR TITLE
add state history

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ ___
 😷 **History**
 * `kovid history COUNTRY` (full history).
 * `kovid history COUNTRY N` (history in the last N days).
+* `kovid history STATE --usa`
 ___
 
 **NOTE:** If you find it irritating to have to type `kovid state STATE`, `covid state STATE` works as well.

--- a/lib/kovid.rb
+++ b/lib/kovid.rb
@@ -68,8 +68,12 @@ module Kovid
     Kovid::Request.cases
   end
 
-  def history(country, last)
-    Kovid::Request.history(country, last)
+  def history(country, days=30)
+    Kovid::Request.history(country, days)
+  end
+
+  def history_us_state(state, days=30)
+    Kovid::Request.history_us_state(state, days)
   end
 
   def histogram(country, date)

--- a/lib/kovid/cli.rb
+++ b/lib/kovid/cli.rb
@@ -75,13 +75,15 @@ module Kovid
       data_source
     end
 
-    desc 'history COUNTRY or history COUNTRY N',
-         'Return history of incidents of COUNTRY (in the last N days)'
-    def history(*params)
-      if params.size == 2
-        puts Kovid.history(params.first, params.last)
+    desc 'history COUNTRY or history COUNTRY N or' \
+         'history STATE --usa',
+         'Return history of incidents of COUNTRY|STATE (in the last N days)'
+    option :usa, :type => :boolean
+    def history(location, days=30)
+      if options[:usa]
+        puts Kovid.history_us_state(location, days)
       else
-        puts Kovid.history(params.first, nil)
+        puts Kovid.history(location, days)
       end
       data_source
     end

--- a/lib/kovid/constants.rb
+++ b/lib/kovid/constants.rb
@@ -23,6 +23,12 @@ module Kovid
       'Recovered'.paint_green
     ].freeze
 
+    DATE_CASES_DEATHS = [
+      'Date'.paint_white,
+      'Cases'.paint_white,
+      'Deaths'.paint_red
+    ].freeze
+
     CONTINENTAL_AGGREGATE_HEADINGS = [
       'Cases'.paint_white,
       'Cases Today'.paint_white,
@@ -93,7 +99,13 @@ module Kovid
       'Recovered'.paint_green
     ].freeze
 
-    FOOTER_LINE = [
+    FOOTER_LINE_THREE_COLUMNS = [
+      '------------',
+      '------------',
+      '------------'
+    ].freeze
+
+    FOOTER_LINE_FOUR_COLUMNS = [
       '------------',
       '------------',
       '------------',

--- a/spec/kovid_spec.rb
+++ b/spec/kovid_spec.rb
@@ -164,11 +164,46 @@ RSpec.describe Kovid do
   end
 
   describe 'history' do
-    it 'returns history of given location' do
+    it 'returns history of given country' do
       table = Kovid.history('ghana', '7')
-
       expect(table.headings.first.cells.first.value).to include('Date')
       expect(table.headings.first.cells.last.value).to include('Recovered')
+    end
+
+    it 'outputs message informing no reported case.' do
+      table = Kovid.history('Extremistan')
+
+      expect(table.rows.first.cells.first.value).to start_with(
+        "Could not find cases for Extremistan"
+      )
+    end
+
+    it 'returns history of given state' do
+      table = Kovid.history_us_state('va', '14')
+      expect(table.headings.first.cells.first.value).to include('Date')
+      expect(table.headings.first.cells.last.value).to include('Deaths')
+      expect(table.title).to eq('VIRGINIA')
+    end
+
+    it 'returns correct amount of records' do
+      table1 = Kovid.history_us_state('ny', '7')
+      expect(table1.rows.size).to eq(7)
+
+      table2 = Kovid.history_us_state('nj', 5)
+      expect(table2.rows.size).to eq(5)
+    end
+
+    it 'adds footers rows when reocrds greater than 10' do
+      table = Kovid.history_us_state('md', '22')
+      expect(table.rows.size).to eq(24)
+    end
+
+    it 'defaults to days (30) for history' do
+      table = Kovid.history_us_state('md')
+      expect(table.title).to eq('MARYLAND')
+
+      # Footer rows add two additional rows
+      expect(table.rows.size).to eq(32)
     end
   end
 end


### PR DESCRIPTION
Added history feature for US States.  Now you can run `kovid history STATE --usa`.  I had to add the usa option due to name collisions. For example, "ca" could either be a country (Canada) or state (California).

In addition, I set a default for the number of days returned (30 days).  This helped me refactor some of code in the `Historian#history` method where it was checking if that argument was passed.

One other thing I modified was the `Request#not_found method` to allow a block to modify message when searching countries/states.  Also, there was a comment in the `Historian#history` method:

> TODO: Write checks for when country is spelt wrong.

Rather than adding the check in this method, I added to `Request#history_us_state`.

