### PR TITLE
refactor historian methods

### DIFF
--- a/lib/kovid/constants.rb
+++ b/lib/kovid/constants.rb
@@ -110,6 +110,9 @@ module Kovid
 
     FOOTER_LINE_FOUR_COLUMNS = FOOTER_LINE_COLUMN * 4
 
+    # Add footer if rows exceed this number
+    ADD_FOOTER_SIZE = 10
+
     COUNTRY_LETTERS = 'A'.upto('Z').with_index(127_462).to_h.freeze
 
     RIGHT_ALIGN_COLUMNS = {

--- a/lib/kovid/helpers.rb
+++ b/lib/kovid/helpers.rb
@@ -25,12 +25,6 @@ module Kovid
     num.to_i.positive? ? "+#{comma_delimit(num)}" : comma_delimit(num).to_s
   end
 
-  def format_country_history_numbers(load)
-    load['timeline'].values.map(&:values).transpose.each do |data|
-      data.map! { |number| Kovid.comma_delimit(number) }
-    end
-  end
-
   def lookup_us_state(state)
     us = Carmen::Country.coded('USA')
     lookup = us.subregions.coded(state) || us.subregions.named(state)


### PR DESCRIPTION
For the #history method, there was a lot of complicated logic that parsed the api response and passed around unspecified arrays for dates and counts.

I encapsulated the logic in a private method #history_rows.  It's a little more explicit and
eliminates some of the complicated chaining of methods.