### PR TITLE
Fix columns mismatched on Country comparisons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kovid (0.6.13)
+    kovid (0.6.14)
       carmen (~> 1.1.3)
       rainbow (~> 3.0)
       terminal-table (~> 1.8)

--- a/lib/kovid/constants.rb
+++ b/lib/kovid/constants.rb
@@ -44,11 +44,13 @@ module Kovid
     COMPARE_COUNTRY_TABLE_FULL = [
       'Country'.paint_white,
       'Cases'.paint_white,
-      'Deaths'.paint_red,
-      'Recovered'.paint_green,
       'Cases Today'.paint_white,
+      'Deaths'.paint_red,
       'Deaths Today'.paint_red,
+      'Active'.paint_yellow,
+      'Recovered'.paint_green,
       'Critical'.paint_yellow,
+      'Tests'.paint_white,
       'Cases/Million'.paint_white
     ].freeze
 
@@ -58,6 +60,7 @@ module Kovid
       'Cases Today'.paint_white,
       'Deaths'.paint_red,
       'Deaths Today'.paint_red,
+      'Active'.paint_yellow,
       'Recovered'.paint_green,
       'Tests'.paint_white
     ].freeze
@@ -69,8 +72,8 @@ module Kovid
       'Deaths Today'.paint_red,
       'Active'.paint_yellow,
       'Recovered'.paint_green,
-      'Tests'.paint_white,
       'Critical'.paint_yellow,
+      'Tests'.paint_white,
       'Cases/Million'.paint_white
     ].freeze
 

--- a/lib/kovid/tablelize.rb
+++ b/lib/kovid/tablelize.rb
@@ -156,9 +156,8 @@ module Kovid
           Kovid.add_plus_sign(data['todayDeaths']),
           Kovid.comma_delimit(data['active']),
           Kovid.comma_delimit(data['recovered']),
-          Kovid.comma_delimit(data['tests']),
-
           Kovid.comma_delimit(data['critical']),
+          Kovid.comma_delimit(data['tests']),
           Kovid.comma_delimit(data['casesPerOneMillion'])
         ]
       end


### PR DESCRIPTION
Related: Issue #116

While comparing multiple countries, some column headers were missing and
some were mistmatched. This PR fixes these cases.

Feel free to reorganize at will :)

Sample screenshots with the case I posted on the issue (I've also noticed the full comparison wasn't working well:
<img width="705" alt="Screenshot 2020-06-06 at 12 11 13" src="https://user-images.githubusercontent.com/32199/83935742-e4266d00-a7ee-11ea-95fa-00150c51b2c3.png">
<img width="892" alt="Screenshot 2020-06-06 at 12 12 51" src="https://user-images.githubusercontent.com/32199/83935757-218afa80-a7ef-11ea-8430-59c13640eb6c.png">

